### PR TITLE
add relative date to comment update and create time

### DIFF
--- a/jirapub.js
+++ b/jirapub.js
@@ -7,6 +7,7 @@ var mod_bunyan = require('bunyan');
 var mod_fs = require('fs');
 var mod_path = require('path');
 var mod_ent = require('ent');
+var mod_human = require('human-time');
 
 var LOG = mod_bunyan.createLogger({
 	name: 'jirapub'
@@ -476,7 +477,8 @@ format_issue(issue)
 		out += '<h2>Resolution</h2>\n';
 		out += '<p><b>' + issue.fields.resolution.name + ':</b> ' +
 		    issue.fields.resolution.description + '<br>\n';
-		out += '(Resolution Date: ' + rd.toISOString() + ')</p>\n';
+		out += '(Resolution Date: ' + rd.toISOString() + ' - ' +
+                    mod_human(rd) + ')</p>\n';
 	}
 
 	if (issue.fields.fixVersions && issue.fields.fixVersions.length > 0) {
@@ -485,7 +487,8 @@ format_issue(issue)
 			var fv = issue.fields.fixVersions[i];
 
 			out += '<p><b>' + fv.name + '</b> (Release Date: ' +
-			    fv.releaseDate + ')</p>\n';
+			    fv.releaseDate + ' - ' +
+                            mod_human(new Date(fv.releaseDate)) + ')</p>\n';
 		}
 	}
 
@@ -519,11 +522,13 @@ format_issue(issue)
 			    (dark ? '#DDDDDD' : '#EEEEEE') + ';">\n';
 			out += '<b>';
 			out += 'Comment by ' + com.author.displayName + '<br>\n';
-			out += 'Created at ' + cdtc.toISOString() + '<br>\n';
+			out += 'Created at ' + cdtc.toISOString() +
+			    ' (' + mod_human(cdtc) + ')<br>\n';
 			if (com.updated && com.updated !== com.created) {
+				var cdtu = new Date(com.updated);
 				out += 'Updated at ' +
-				    new Date(com.updated).toISOString() +
-				    '<br>\n';
+				    cdtu.toISOString() +
+				    ' (' + mod_human(cdtu) + ')<br>\n';
 			}
 			out += '</b>';
 			out += format_markup(com.body);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "assert-plus": "^0.1.5",
     "bunyan": "~0.22.1",
     "ent": "~2.0.0",
+    "human-time": "0.0.0",
     "restify": "~2.6.1"
   }
 }


### PR DESCRIPTION
This change uses the module [human-time](https://github.com/bahamas10/human) to turn `Date` objects into strings that give a relative time, like `5 minutes ago`, `2 days ago`, `4 months ago`, etc. getting fuzzier as the delta increases.  I've modified the code to give a relative date anywhere I saw an absolute date being used, but as I don't have Jira setup I'm currently unable to test this.

(using https://smartos.org/bugview/TOOLS-843 as an example)

before

```
Comment by Lloyd Dewolf
Created at 2015-03-06T18:26:30.000Z
Updated at 2015-03-06T18:28:30.000Z
```

after

```
Comment by Lloyd Dewolf
Created at 2015-03-06T18:26:30.000Z (5 days ago)
Updated at 2015-03-06T18:28:30.000Z (5 days ago)
```