### PR TITLE
TOOLS-2144 bugview hides quoted paragraphs

### DIFF
--- a/jirapub.js
+++ b/jirapub.js
@@ -789,6 +789,8 @@ format_markup(desc)
 		ps_list: false,
 		ps_heading: null
 	};
+	var show_empty = true;
+
 	for (var i = 0; i < lines.length; i++) {
 		var line = lines[i];
 		var lt_noformat = !!line.match(/^{noformat/);
@@ -797,6 +799,7 @@ format_markup(desc)
 		var lt_quote = !!line.match(/^{quote/);
 
 		if (lt_noformat || lt_code || lt_panel || lt_quote) {
+			show_empty = false;
 			if (parser_state.ps_list) {
 				parser_state.ps_list = false;
 				out += '</ul>\n';
@@ -804,12 +807,14 @@ format_markup(desc)
 			if (fmton) {
 				parse_markup = true;
 				out += (lt_quote ? '</div>' : '</pre>') + '\n';
+				line = '';
 			} else if (lt_quote) {
 				newline_br = true;
 				parse_markup = true;
 				out += '<div style="border-left: 2px solid ' +
 				    '#888888; margin-left: 1em; ' +
 				    'padding-left: 1em">\n';
+				line = line.match(/^{[^}]*}?(.*)/)[1];
 			} else {
 				newline_br = false;
 				parse_markup = !(lt_noformat || lt_code);
@@ -817,9 +822,11 @@ format_markup(desc)
 				    'font-family: Menlo, Courier, ' +
 				    'Lucida Console, Monospace;' +
 				    'background-color: #eeeeee;">\n';
+				line = line.match(/^{[^}]*}?(.*)/)[1];
 			}
 			fmton = !fmton;
-		} else {
+		}
+		if (show_empty || line !== '') {
 			if (parse_markup) {
 				out += parse_jira_markup(line, parser_state);
 			} else {
@@ -828,11 +835,11 @@ format_markup(desc)
 			if (fmton) {
 				out += newline_br ? '<br>\n' : '\n';
 			} else if (parser_state.ps_heading === null &&
-			    !last_was_heading) {
+				!last_was_heading) {
 				out += '<br>\n';
 			}
 		}
-
+		show_empty = true
 		last_was_heading = (parser_state.ps_heading !== null);
 	}
 


### PR DESCRIPTION
Now looks prettier.  Compare the screenshot below to [current bugview](https://smartos.org/bugview/TOOLS-2144).
<img width="738" alt="screen shot 2019-01-03 at 3 02 16 pm" src="https://user-images.githubusercontent.com/8992389/50661405-a6be1000-0f68-11e9-8c23-d83d906caee7.png">